### PR TITLE
Faulty PNG tiles fixes

### DIFF
--- a/PBMap.pb
+++ b/PBMap.pb
@@ -2712,6 +2712,7 @@ Module PBMap
           ;*PBMap\MemCache\Images(key)\Tile = *Tile\Size
           If *Tile\Size
             ;TODO : check if file size = server file size
+            ;and eventually use pngcheck to avoid problematic files http://www.libpng.org/pub/png/apps/pngcheck.html
             *PBMap\MemCache\Images(key)\Tile = -1 ; Web loading thread has finished successfully
             ; Allows to post edit the tile image file with a customised code
             If *PBMap\CallBackModifyTileFile
@@ -3191,8 +3192,8 @@ CompilerIf #PB_Compiler_IsMainFile
 CompilerEndIf
 
 ; IDE Options = PureBasic 5.70 LTS (Windows - x64)
-; CursorPosition = 1245
-; FirstLine = 1230
+; CursorPosition = 2714
+; FirstLine = 2702
 ; Folding = ---------------------
 ; EnableThread
 ; EnableXP

--- a/PBMap.pb
+++ b/PBMap.pb
@@ -2543,6 +2543,7 @@ Module PBMap
             EndIf
           Next
         EndIf
+        ; YA To select a track with LMB
         If *PBMap\EditMarker = #False 
           Location\Latitude = GetMouseLatitude(MapGadget)
           Location\Longitude = GetMouseLongitude(MapGadget)

--- a/PBMap.pb
+++ b/PBMap.pb
@@ -1181,10 +1181,30 @@ Module PBMap
     UnlockMutex(*PBMap\MemoryCacheAccessMutex)
   EndProcedure
   
+  ;- LoadImage workaround
+  ; by idle
+  ; Check that the file is valid
+  Procedure _LoadImage(ImageNumber, File.s) 
+    Protected fn, pat, pos, res
+    If UCase(GetExtensionPart(File)) = "PNG"
+      pat = $444E4549
+      fn= ReadFile(#PB_Any, File) 
+      If fn 
+        pos = Lof(fn)
+        FileSeek(fn, pos - 8)
+        res = ReadLong(fn)
+        CloseFile(fn)
+        If res = pat 
+          ProcedureReturn LoadImage(ImageNumber, File)  
+        EndIf   
+      EndIf
+    EndIf
+  EndProcedure
+
   Procedure.i GetTileFromHDD(*PBMap.PBMap, CacheFile.s) ;Directly pass the PBMap structure (faster)
     Protected nImage.i, LifeTime.i, MaxLifeTime.i
       ; Everything is OK, loads the file
-      nImage = LoadImage(#PB_Any, CacheFile)
+      nImage = _LoadImage(#PB_Any, CacheFile)
       If nImage
         MyDebug(*PBMap, " Success loading " + CacheFile + " as nImage " + Str(nImage), 3)
         ProcedureReturn nImage  
@@ -3192,8 +3212,8 @@ CompilerIf #PB_Compiler_IsMainFile
 CompilerEndIf
 
 ; IDE Options = PureBasic 5.70 LTS (Windows - x64)
-; CursorPosition = 2714
-; FirstLine = 2702
+; CursorPosition = 2962
+; FirstLine = 2945
 ; Folding = ---------------------
 ; EnableThread
 ; EnableXP

--- a/PBMap.pb
+++ b/PBMap.pb
@@ -1,4 +1,4 @@
-; ******************************************************************** 
+﻿; ******************************************************************** 
 ; Program:           PBMap
 ; Description:       Permits the use of tiled maps like 
 ;                    OpenStreetMap in a handy PureBASIC module
@@ -2543,14 +2543,13 @@ Module PBMap
             EndIf
           Next
         EndIf
-        ; YA pour sélectionner un point de la trace avec le clic gauche
         If *PBMap\EditMarker = #False 
           Location\Latitude = GetMouseLatitude(MapGadget)
           Location\Longitude = GetMouseLongitude(MapGadget)
           If *PBMap\CallBackLeftClic > 0
             CallFunctionFast(*PBMap\CallBackLeftClic, @Location)
           EndIf 
-          ; ajout YA // change la forme du pointeur de souris pour les déplacements de la carte
+          ; ajout YA // Mouse pointer when moving map
           SetGadgetAttribute(*PBMap\Gadget, #PB_Canvas_Cursor, #PB_Cursor_Hand)
         Else
           SetGadgetAttribute(*PBMap\Gadget, #PB_Canvas_Cursor, #PB_Cursor_Default) ; ajout YA pour remettre le pointeur souris en normal
@@ -2608,7 +2607,7 @@ Module PBMap
               EndIf
             Next
             ; Check if mouse touch tracks           
-            If *PBMap\Options\ShowTrackSelection ; YA ajout pour éviter la sélection de la trace
+            If *PBMap\Options\ShowTrackSelection ; YA to avoid selecting track
               With *PBMap\TracksList()
                 ; Trace Track
                 If ListSize(*PBMap\TracksList()) > 0
@@ -2642,11 +2641,11 @@ Module PBMap
           EndIf
         EndIf
       Case #PB_EventType_LeftButtonUp
-        SetGadgetAttribute(*PBMap\Gadget,#PB_Canvas_Cursor,#PB_Cursor_Default) ; ajout YA pour remettre le pointeur souris en normal
+        SetGadgetAttribute(*PBMap\Gadget,#PB_Canvas_Cursor,#PB_Cursor_Default) ;  YA normal mouse pointer
                                                                                ; *PBMap\MoveStartingPoint\x = - 1
         *PBMap\Dragging = #False
         *PBMap\Redraw = #True
-        ;YA pour connaitre les coordonnées d'un marqueur après déplacement
+        ;YA to knows marker coordinates after moving
         ForEach *PBMap\Markers()
           If *PBMap\Markers()\Selected = #True
             If *PBMap\CallBackMarker > 0
@@ -3141,9 +3140,9 @@ CompilerIf #PB_Compiler_IsMainFile
 CompilerEndIf
 
 
-; IDE Options = PureBasic 5.61 (Windows - x86)
-; CursorPosition = 517
-; FirstLine = 513
+; IDE Options = PureBasic 5.61 (Windows - x64)
+; CursorPosition = 2648
+; FirstLine = 2606
 ; Folding = ---------------------
 ; EnableThread
 ; EnableXP

--- a/PBMap.pb
+++ b/PBMap.pb
@@ -1183,7 +1183,7 @@ Module PBMap
   
   ;- LoadImage workaround
   ; by idle
-  ; Check that the file is valid
+  ; Check that the PNG file is valid
   Procedure _LoadImage(ImageNumber, File.s) 
     Protected fn, pat, pos, res
     If UCase(GetExtensionPart(File)) = "PNG"
@@ -3212,8 +3212,8 @@ CompilerIf #PB_Compiler_IsMainFile
 CompilerEndIf
 
 ; IDE Options = PureBasic 5.70 LTS (Windows - x64)
-; CursorPosition = 2962
-; FirstLine = 2945
+; CursorPosition = 1185
+; FirstLine = 1171
 ; Folding = ---------------------
 ; EnableThread
 ; EnableXP

--- a/PBMap.pb
+++ b/PBMap.pb
@@ -1273,7 +1273,7 @@ Module PBMap
     EndIf
     ; End of the memory cache access
     ;LockMutex(*PBMap\MemoryCacheAccessMutex)
-    PostEvent(#PB_Event_Gadget, *Tile\Window, *Tile\Gadget, #PB_MAP_TILE_CLEANUP, *Tile) ; To free memory outside the thread
+    PostEvent(#PB_Event_Gadget, *Tile\Window, *Tile\Gadget, #PB_MAP_TILE_CLEANUP, *Tile) ; To free memory and eventually delete aborted image file outside the thread
     ;UnlockMutex(*PBMap\MemoryCacheAccessMutex)
   EndProcedure
   
@@ -2720,6 +2720,11 @@ Module PBMap
             EndIf
           Else
             *PBMap\MemCache\Images(key)\Tile = 0
+            If DeleteFile(*Tile\CacheFile)
+              MyDebug(*PBMap, "  Deleting not fully loaded image file  " + *Tile\CacheFile, 3)
+            Else
+              MyDebug(*PBMap, "  Can't delete not fully loaded image file  " + *Tile\CacheFile, 3)
+            EndIf
           EndIf
         EndIf
         FreeMemory(*Tile)                                       ; Frees the data needed for the thread (*tile=*PBMap\MemCache\Images(key)\Tile)
@@ -3183,8 +3188,8 @@ CompilerIf #PB_Compiler_IsMainFile
 CompilerEndIf
 
 ; IDE Options = PureBasic 5.70 LTS (Windows - x64)
-; CursorPosition = 1369
-; FirstLine = 1354
+; CursorPosition = 1261
+; FirstLine = 1242
 ; Folding = ---------------------
 ; EnableThread
 ; EnableXP

--- a/PBMap.pb
+++ b/PBMap.pb
@@ -515,7 +515,7 @@ Module PBMap
     Protected *PBMap.PBMap = PBMaps(Str(MapGadget))
     Protected n.d = *PBMap\TileSize * Pow(2.0, Zoom)
     ; Ensures the longitude to be in the range [-180; 180[
-    *Location\Longitude  = Mod(Mod(*Coords\x / n * 360.0, 360.0) + 360.0, 360.0) - 180
+    *Location\Longitude  = Mod((1 + *Coords\x / n) * 360, 360) - 180 ; Mod(Mod(*Coords\x / n * 360.0, 360.0) + 360.0, 360.0) - 180
     *Location\Latitude = Degree(ATan(SinH(#PI * (1.0 - 2.0 * *Coords\y / n))))
     If *Location\Latitude <= -89 
       *Location\Latitude = -89 
@@ -3141,9 +3141,9 @@ CompilerIf #PB_Compiler_IsMainFile
 CompilerEndIf
 
 
-; IDE Options = PureBasic 5.61 (Windows - x64)
-; CursorPosition = 2751
-; FirstLine = 2744
+; IDE Options = PureBasic 5.61 (Windows - x86)
+; CursorPosition = 517
+; FirstLine = 513
 ; Folding = ---------------------
 ; EnableThread
 ; EnableXP

--- a/PBMap.pb
+++ b/PBMap.pb
@@ -1243,6 +1243,7 @@ Module PBMap
     ;UnlockMutex(*PBMap\MemoryCacheAccessMutex)
     *Tile\Size = 0
     *Tile\Download = ReceiveHTTPFile(*Tile\URL, *Tile\CacheFile, #PB_HTTP_Asynchronous, #USERAGENT)
+    ;TODO : obtain original file size to compare and eventually delete truncated file
     If *Tile\Download
       Repeat
         Progress = HTTPProgress(*Tile\Download)
@@ -1273,7 +1274,8 @@ Module PBMap
     EndIf
     ; End of the memory cache access
     ;LockMutex(*PBMap\MemoryCacheAccessMutex)
-    PostEvent(#PB_Event_Gadget, *Tile\Window, *Tile\Gadget, #PB_MAP_TILE_CLEANUP, *Tile) ; To free memory and eventually delete aborted image file outside the thread
+    ; To free memory and eventually delete aborted image file outside the thread
+    PostEvent(#PB_Event_Gadget, *Tile\Window, *Tile\Gadget, #PB_MAP_TILE_CLEANUP, *Tile) 
     ;UnlockMutex(*PBMap\MemoryCacheAccessMutex)
   EndProcedure
   
@@ -2709,6 +2711,7 @@ Module PBMap
           ; If the map element has not been deleted during the thread lifetime (should not occur)
           ;*PBMap\MemCache\Images(key)\Tile = *Tile\Size
           If *Tile\Size
+            ;TODO : check if file size = server file size
             *PBMap\MemCache\Images(key)\Tile = -1 ; Web loading thread has finished successfully
             ; Allows to post edit the tile image file with a customised code
             If *PBMap\CallBackModifyTileFile
@@ -3188,8 +3191,8 @@ CompilerIf #PB_Compiler_IsMainFile
 CompilerEndIf
 
 ; IDE Options = PureBasic 5.70 LTS (Windows - x64)
-; CursorPosition = 1261
-; FirstLine = 1242
+; CursorPosition = 1245
+; FirstLine = 1230
 ; Folding = ---------------------
 ; EnableThread
 ; EnableXP

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# PBMap
+# PBMap 0.91
 Open source tiled map software.
 
-To develop tiled map applications in PureBasic.
+Module to develop tiled map applications in PureBasic, like  like OpenStreetMap(c), Google Maps(c), Here(c), ...
 
-Based on OpenStreetMap services
+Functional example based on OpenStreetMap services(c)
 OSM copyright : http://www.openstreetmap.org/copyright
 
-This code is free, but any use should mention the origin of this code.
+This code is free, but any user should mention the origin of this code.
 
-Officials forums topics here :
+Official forums topics :
 http://www.purebasic.fr/english/viewtopic.php?f=27&t=66320 (english)
 http://www.purebasic.fr/french/viewtopic.php?f=3&t=16160 (french)
 
@@ -16,6 +16,11 @@ Contributors :
 Thyphoon
 djes
 Idle
+
+Thanks to :
 Progi1984
 yves86
-André
+AndrÃ©
+falsam
+
+Special thanks to Fred and Fantaisie Software's team

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@ Open source tiled map software.
 
 Module to develop tiled map applications in PureBasic, like  like OpenStreetMap(c), Google Maps(c), Here(c), ...
 
+
 Functional example based on OpenStreetMap services(c)
+
 OSM copyright : http://www.openstreetmap.org/copyright
+
 
 This code is free, but any user should mention the origin of this code.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Open source tiled map software.
 Module to develop tiled map applications in PureBasic, like  like OpenStreetMap(c), Google Maps(c), Here(c), ...
 
 
-Functional example based on OpenStreetMap services(c)
+Functional example based on OpenStreetMap(c) services
 
 OSM copyright : http://www.openstreetmap.org/copyright
 


### PR DESCRIPTION
Several modifications to ensure that faulty downloads and png files are not processed by loadimage(), which could lead to crash. idle's code to check png files. Falsam OnError() code included.